### PR TITLE
Add option to disable register message spam

### DIFF
--- a/paper/src/main/java/rocks/gravili/notquests/paper/managers/Configuration.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/managers/Configuration.java
@@ -42,7 +42,7 @@ public class Configuration {
     public String configurationVersion = "";
 
     public boolean debug = false;
-    public boolean loadingMessages = true;
+    public boolean verboseLoadingMessages = true;
 
     /**
      * MYSQL Database Connection Information
@@ -256,16 +256,16 @@ public class Configuration {
         return debug;
     }
 
-    public boolean isLoadingMessages() {
-        return loadingMessages;
+    public boolean isVerboseLoadingMessages() {
+        return verboseLoadingMessages;
     }
 
     public void setDebug(boolean debug) {
         this.debug = debug;
     }
 
-    public void setLoadingMessages(boolean loadingMessages) {
-        this.loadingMessages = loadingMessages;
+    public void setVerboseLoadingMessages(boolean verboseLoadingMessages) {
+        this.verboseLoadingMessages = verboseLoadingMessages;
     }
 
     public String getDatabaseHost() {

--- a/paper/src/main/java/rocks/gravili/notquests/paper/managers/Configuration.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/managers/Configuration.java
@@ -42,6 +42,7 @@ public class Configuration {
     public String configurationVersion = "";
 
     public boolean debug = false;
+    public boolean loadingMessages = true;
 
     /**
      * MYSQL Database Connection Information
@@ -255,8 +256,16 @@ public class Configuration {
         return debug;
     }
 
+    public boolean isLoadingMessages() {
+        return loadingMessages;
+    }
+
     public void setDebug(boolean debug) {
         this.debug = debug;
+    }
+
+    public void setLoadingMessages(boolean loadingMessages) {
+        this.loadingMessages = loadingMessages;
     }
 
     public String getDatabaseHost() {

--- a/paper/src/main/java/rocks/gravili/notquests/paper/managers/DataManager.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/managers/DataManager.java
@@ -550,6 +550,10 @@ public class DataManager {
                 false,
                 "Having debug enabled will send more detailed logs into the console, which becomes very spammy."
         ));
+        configuration.setLoadingMessages(getGeneralConfigBoolean(
+                "loading-messages",
+                true
+        ));
 
         //Storage Stuff
         {

--- a/paper/src/main/java/rocks/gravili/notquests/paper/managers/DataManager.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/managers/DataManager.java
@@ -1111,7 +1111,7 @@ public class DataManager {
         configuration.setVerboseLoadingMessages(getGeneralConfigBoolean(
                 "logging.verbose-startup-messages",
                 false,
-                "Inventory slot in which the journal should appear."
+                "If set to true, more startup messages will be logged."
         ));
 
         ItemStack journal = new ItemStack(Material.ENCHANTED_BOOK, 1);

--- a/paper/src/main/java/rocks/gravili/notquests/paper/managers/DataManager.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/managers/DataManager.java
@@ -550,10 +550,6 @@ public class DataManager {
                 false,
                 "Having debug enabled will send more detailed logs into the console, which becomes very spammy."
         ));
-        configuration.setLoadingMessages(getGeneralConfigBoolean(
-                "loading-messages",
-                true
-        ));
 
         //Storage Stuff
         {
@@ -1109,6 +1105,12 @@ public class DataManager {
         configuration.setJournalInventorySlot(getGeneralConfigInt(
                 "general.journal-item.inventory-slot",
                 8,
+                "Inventory slot in which the journal should appear."
+        ));
+
+        configuration.setVerboseLoadingMessages(getGeneralConfigBoolean(
+                "logging.verbose-startup-messages",
+                false,
                 "Inventory slot in which the journal should appear."
         ));
 

--- a/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/ActionManager.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/ActionManager.java
@@ -89,7 +89,7 @@ public class ActionManager {
 
 
     public void registerAction(final String identifier, final Class<? extends Action> action) {
-        if (main.getConfiguration().isDebug()) {
+        if (main.getConfiguration().isVerboseLoadingMessages()) {
             main.getLogManager().info("Registering action <highlight>" + identifier);
         }
         actions.put(identifier, action);

--- a/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/ActionManager.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/ActionManager.java
@@ -89,7 +89,9 @@ public class ActionManager {
 
 
     public void registerAction(final String identifier, final Class<? extends Action> action) {
-        main.getLogManager().info("Registering action <highlight>" + identifier);
+        if (main.getConfiguration().isDebug()) {
+            main.getLogManager().info("Registering action <highlight>" + identifier);
+        }
         actions.put(identifier, action);
 
         try {

--- a/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/ConditionsManager.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/ConditionsManager.java
@@ -86,7 +86,7 @@ public class ConditionsManager {
 
 
     public void registerCondition(final String identifier, final Class<? extends Condition> condition) {
-        if (main.getConfiguration().isLoadingMessages()) {
+        if (main.getConfiguration().isVerboseLoadingMessages()) {
             main.getLogManager().info("Registering condition <highlight>" + identifier);
         }
         conditions.put(identifier, condition);

--- a/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/ConditionsManager.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/ConditionsManager.java
@@ -86,7 +86,9 @@ public class ConditionsManager {
 
 
     public void registerCondition(final String identifier, final Class<? extends Condition> condition) {
-        main.getLogManager().info("Registering condition <highlight>" + identifier);
+        if (main.getConfiguration().isLoadingMessages()) {
+            main.getLogManager().info("Registering condition <highlight>" + identifier);
+        }
         conditions.put(identifier, condition);
 
         try {

--- a/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/ObjectiveManager.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/ObjectiveManager.java
@@ -112,7 +112,7 @@ public class ObjectiveManager {
     }*/
 
     public void registerObjective(final String identifier, final Class<? extends Objective> objective) {
-        if (main.getConfiguration().isDebug()) {
+        if (main.getConfiguration().isVerboseLoadingMessages()) {
             main.getLogManager().info("Registering objective <highlight>" + identifier);
         }
         objectives.put(identifier, objective);

--- a/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/ObjectiveManager.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/ObjectiveManager.java
@@ -112,7 +112,9 @@ public class ObjectiveManager {
     }*/
 
     public void registerObjective(final String identifier, final Class<? extends Objective> objective) {
-        main.getLogManager().info("Registering objective <highlight>" + identifier);
+        if (main.getConfiguration().isDebug()) {
+            main.getLogManager().info("Registering objective <highlight>" + identifier);
+        }
         objectives.put(identifier, objective);
 
         try {

--- a/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/TriggerManager.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/TriggerManager.java
@@ -65,7 +65,9 @@ public class TriggerManager {
 
 
     public void registerTrigger(final String identifier, final Class<? extends Trigger> trigger) {
-        main.getLogManager().info("Registering trigger <highlight>" + identifier);
+        if (main.getConfiguration().isDebug()) {
+            main.getLogManager().info("Registering trigger <highlight>" + identifier);
+        }
         triggers.put(identifier, trigger);
 
         try {

--- a/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/TriggerManager.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/TriggerManager.java
@@ -65,7 +65,7 @@ public class TriggerManager {
 
 
     public void registerTrigger(final String identifier, final Class<? extends Trigger> trigger) {
-        if (main.getConfiguration().isDebug()) {
+        if (main.getConfiguration().isVerboseLoadingMessages()) {
             main.getLogManager().info("Registering trigger <highlight>" + identifier);
         }
         triggers.put(identifier, trigger);

--- a/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/VariablesManager.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/VariablesManager.java
@@ -163,7 +163,9 @@ public class VariablesManager {
 
 
     public void registerVariable(final String identifier, final Class<? extends Variable<?>> variable) {
-        main.getLogManager().info("Registering Variable <highlight>" + identifier);
+        if (main.getConfiguration().isDebug()) {
+            main.getLogManager().info("Registering Variable <highlight>" + identifier);
+        }
         variables.put(identifier, variable);
 
 

--- a/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/VariablesManager.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/managers/registering/VariablesManager.java
@@ -163,7 +163,7 @@ public class VariablesManager {
 
 
     public void registerVariable(final String identifier, final Class<? extends Variable<?>> variable) {
-        if (main.getConfiguration().isDebug()) {
+        if (main.getConfiguration().isVerboseLoadingMessages()) {
             main.getLogManager().info("Registering Variable <highlight>" + identifier);
         }
         variables.put(identifier, variable);

--- a/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/BooleanCondition.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/BooleanCondition.java
@@ -72,7 +72,7 @@ public class BooleanCondition extends Condition {
                 continue;
             }
 
-            if (main.getConfiguration().isLoadingMessages()) {
+            if (main.getConfiguration().isVerboseLoadingMessages()) {
                 main.getLogManager().info("Registering boolean condition: <highlight>" + variableString);
             }
 

--- a/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/BooleanCondition.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/BooleanCondition.java
@@ -72,7 +72,9 @@ public class BooleanCondition extends Condition {
                 continue;
             }
 
-            main.getLogManager().info("Registering boolean condition: <highlight>" + variableString);
+            if (main.getConfiguration().isLoadingMessages()) {
+                main.getLogManager().info("Registering boolean condition: <highlight>" + variableString);
+            }
 
 
             manager.command(main.getVariablesManager().registerVariableCommands(variableString, builder)

--- a/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/ItemStackListCondition.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/ItemStackListCondition.java
@@ -188,7 +188,9 @@ public class ItemStackListCondition extends Condition {
                 continue;
             }
 
-            main.getLogManager().info("Registering ItemStackList condition: <highlight>" + variableString);
+            if (main.getConfiguration().isLoadingMessages()) {
+                main.getLogManager().info("Registering ItemStackList condition: <highlight>" + variableString);
+			}
 
             manager.command(main.getVariablesManager().registerVariableCommands(variableString, builder)
                     .argument(StringArgument.<CommandSender>newBuilder("operator").withSuggestionsProvider((context, lastString) -> {

--- a/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/ItemStackListCondition.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/ItemStackListCondition.java
@@ -188,7 +188,7 @@ public class ItemStackListCondition extends Condition {
                 continue;
             }
 
-            if (main.getConfiguration().isLoadingMessages()) {
+            if (main.getConfiguration().isVerboseLoadingMessages()) {
                 main.getLogManager().info("Registering ItemStackList condition: <highlight>" + variableString);
 			}
 

--- a/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/ListCondition.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/ListCondition.java
@@ -200,7 +200,7 @@ public class ListCondition extends Condition {
             if (main.getVariablesManager().alreadyFullRegisteredVariables.contains(variableString)) {
                 continue;
             }
-            if (main.getConfiguration().isLoadingMessages()) {
+            if (main.getConfiguration().isVerboseLoadingMessages()) {
                 main.getLogManager().info("Registering list condition: <highlight>" + variableString);
             }
 

--- a/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/ListCondition.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/ListCondition.java
@@ -200,8 +200,9 @@ public class ListCondition extends Condition {
             if (main.getVariablesManager().alreadyFullRegisteredVariables.contains(variableString)) {
                 continue;
             }
-
-            main.getLogManager().info("Registering list condition: <highlight>" + variableString);
+            if (main.getConfiguration().isLoadingMessages()) {
+                main.getLogManager().info("Registering list condition: <highlight>" + variableString);
+            }
 
             manager.command(main.getVariablesManager().registerVariableCommands(variableString, builder)
                     .argument(StringArgument.<CommandSender>newBuilder("operator").withSuggestionsProvider((context, lastString) -> {

--- a/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/NumberCondition.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/NumberCondition.java
@@ -70,7 +70,7 @@ public class NumberCondition extends Condition {
                 continue;
             }
 
-            if (main.getConfiguration().isLoadingMessages()) {
+            if (main.getConfiguration().isVerboseLoadingMessages()) {
                 main.getLogManager().info("Registering number condition: <highlight>" + variableString);
             }
 

--- a/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/NumberCondition.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/NumberCondition.java
@@ -70,7 +70,9 @@ public class NumberCondition extends Condition {
                 continue;
             }
 
-            main.getLogManager().info("Registering number condition: <highlight>" + variableString);
+            if (main.getConfiguration().isLoadingMessages()) {
+                main.getLogManager().info("Registering number condition: <highlight>" + variableString);
+            }
 
 
             manager.command(main.getVariablesManager().registerVariableCommands(variableString, builder)

--- a/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/StringCondition.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/StringCondition.java
@@ -144,7 +144,7 @@ public class StringCondition extends Condition {
                 continue;
             }
 
-            if (main.getConfiguration().isLoadingMessages()) {
+            if (main.getConfiguration().isVerboseLoadingMessages()) {
                 main.getLogManager().info("Registering string condition: <highlight>" + variableString);
             }
 

--- a/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/StringCondition.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/structs/conditions/StringCondition.java
@@ -144,7 +144,9 @@ public class StringCondition extends Condition {
                 continue;
             }
 
-            main.getLogManager().info("Registering string condition: <highlight>" + variableString);
+            if (main.getConfiguration().isLoadingMessages()) {
+                main.getLogManager().info("Registering string condition: <highlight>" + variableString);
+            }
 
 
             manager.command(main.getVariablesManager().registerVariableCommands(variableString, builder)

--- a/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/Configuration.java
+++ b/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/Configuration.java
@@ -31,6 +31,7 @@ import java.util.List;
 public class Configuration {
 
     public boolean debug = false;
+    public boolean loadingMessages = true;
 
     /**
      * MYSQL Database Connection Information
@@ -142,6 +143,10 @@ public class Configuration {
 
     public Configuration() {
 
+    }
+
+    public final Boolean getLoadingMessages() {
+        return loadingMessages;
     }
 
     public final String getDatabaseHost() {

--- a/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/Configuration.java
+++ b/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/Configuration.java
@@ -31,7 +31,7 @@ import java.util.List;
 public class Configuration {
 
     public boolean debug = false;
-    public boolean loadingMessages = true;
+    public boolean verboseLoadingMessages = true;
 
     /**
      * MYSQL Database Connection Information
@@ -145,8 +145,8 @@ public class Configuration {
 
     }
 
-    public final Boolean getLoadingMessages() {
-        return loadingMessages;
+    public final Boolean getVerboseLoadingMessages() {
+        return verboseLoadingMessages;
     }
 
     public final String getDatabaseHost() {

--- a/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/DataManager.java
+++ b/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/DataManager.java
@@ -374,6 +374,12 @@ public class DataManager {
         }
         configuration.debug = getGeneralConfig().getBoolean(key);
 
+        key = "loading-messages";
+        if (!getGeneralConfig().isBoolean(key)) {
+            getGeneralConfig().set(key, false);
+            valueChanged = true;
+        }
+        configuration.loadingMessages = getGeneralConfig().getBoolean(key);
 
         //Other values from general.yml
         key = "general.max-active-quests-per-player";

--- a/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/DataManager.java
+++ b/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/DataManager.java
@@ -374,7 +374,7 @@ public class DataManager {
         }
         configuration.debug = getGeneralConfig().getBoolean(key);
 
-        key = "loading-messages";
+        key = "logging.verbose-startup-messages";
         if (!getGeneralConfig().isBoolean(key)) {
             getGeneralConfig().set(key, false);
             valueChanged = true;

--- a/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/registering/ActionManager.java
+++ b/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/registering/ActionManager.java
@@ -74,7 +74,7 @@ public class ActionManager {
 
 
     public void registerAction(final String identifier, final Class<? extends Action> action) {
-        if (main.getConfiguration().getLoadingMessages()) {
+        if (main.getConfiguration().getVerboseLoadingMessages()) {
             main.getLogManager().info("Registering action <AQUA>" + identifier);
         }
         actions.put(identifier, action);

--- a/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/registering/ActionManager.java
+++ b/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/registering/ActionManager.java
@@ -74,7 +74,9 @@ public class ActionManager {
 
 
     public void registerAction(final String identifier, final Class<? extends Action> action) {
-        main.getLogManager().info("Registering action <AQUA>" + identifier);
+        if (main.getConfiguration().getLoadingMessages()) {
+            main.getLogManager().info("Registering action <AQUA>" + identifier);
+        }
         actions.put(identifier, action);
 
         try {

--- a/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/registering/ConditionsManager.java
+++ b/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/registering/ConditionsManager.java
@@ -82,7 +82,9 @@ public class ConditionsManager {
 
 
     public void registerCondition(final String identifier, final Class<? extends Condition> condition) {
-        main.getLogManager().info("Registering condition <AQUA>" + identifier);
+        if (main.getConfiguration().getLoadingMessages()) {
+            main.getLogManager().info("Registering condition <AQUA>" + identifier);
+        }
         conditions.put(identifier, condition);
 
         try {

--- a/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/registering/ConditionsManager.java
+++ b/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/registering/ConditionsManager.java
@@ -82,7 +82,7 @@ public class ConditionsManager {
 
 
     public void registerCondition(final String identifier, final Class<? extends Condition> condition) {
-        if (main.getConfiguration().getLoadingMessages()) {
+        if (main.getConfiguration().getVerboseLoadingMessages()) {
             main.getLogManager().info("Registering condition <AQUA>" + identifier);
         }
         conditions.put(identifier, condition);

--- a/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/registering/ObjectiveManager.java
+++ b/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/registering/ObjectiveManager.java
@@ -100,7 +100,7 @@ public class ObjectiveManager {
     }*/
 
     public void registerObjective(final String identifier, final Class<? extends Objective> objective) {
-        if (main.getConfiguration().getLoadingMessages()) {
+        if (main.getConfiguration().getVerboseLoadingMessages()) {
             main.getLogManager().info("Registering objective <AQUA>" + identifier);
         }
         objectives.put(identifier, objective);

--- a/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/registering/ObjectiveManager.java
+++ b/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/registering/ObjectiveManager.java
@@ -100,7 +100,9 @@ public class ObjectiveManager {
     }*/
 
     public void registerObjective(final String identifier, final Class<? extends Objective> objective) {
-        main.getLogManager().info("Registering objective <AQUA>" + identifier);
+        if (main.getConfiguration().getLoadingMessages()) {
+            main.getLogManager().info("Registering objective <AQUA>" + identifier);
+        }
         objectives.put(identifier, objective);
 
         try {

--- a/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/registering/TriggerManager.java
+++ b/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/registering/TriggerManager.java
@@ -66,7 +66,9 @@ public class TriggerManager {
 
 
     public void registerTrigger(final String identifier, final Class<? extends Trigger> trigger) {
-        main.getLogManager().info("Registering trigger <AQUA>" + identifier);
+        if (main.getConfiguration().getLoadingMessages()) {
+            main.getLogManager().info("Registering trigger <AQUA>" + identifier);
+        }
         triggers.put(identifier, trigger);
 
         try {

--- a/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/registering/TriggerManager.java
+++ b/spigot/src/main/java/rocks/gravili/notquests/spigot/managers/registering/TriggerManager.java
@@ -66,7 +66,7 @@ public class TriggerManager {
 
 
     public void registerTrigger(final String identifier, final Class<? extends Trigger> trigger) {
-        if (main.getConfiguration().getLoadingMessages()) {
+        if (main.getConfiguration().getVerboseLoadingMessages()) {
             main.getLogManager().info("Registering trigger <AQUA>" + identifier);
         }
         triggers.put(identifier, trigger);


### PR DESCRIPTION
I noticed that registering conditions causes a lot of spam in logs. So I added a config option to disable it (it sends them by default).

I also consider changing the option name to log-register but let me know if I should do that.