### PR TITLE
Fix quest npc hologram despawning

### DIFF
--- a/paper/src/main/java/rocks/gravili/notquests/paper/events/hooks/CitizensEvents.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/events/hooks/CitizensEvents.java
@@ -186,7 +186,7 @@ public class CitizensEvents implements Listener {
                         }
 
                     }
-
+                    player.updateInventory();
                 }
             }
         });

--- a/paper/src/main/java/rocks/gravili/notquests/paper/managers/integrations/citizens/QuestGiverNPCTrait.java
+++ b/paper/src/main/java/rocks/gravili/notquests/paper/managers/integrations/citizens/QuestGiverNPCTrait.java
@@ -228,7 +228,11 @@ public class QuestGiverNPCTrait extends Trait {
   // Run code when the NPC is despawned. This is called before the entity actually despawns so
   // npc.getEntity() is still valid.
   @Override
-  public void onDespawn() {}
+  public void onDespawn() {
+    if(getNPC().getEntity() != null){
+      getNPC().getEntity().getPassengers().forEach(Entity::remove);
+    }
+  }
 
   // Run code when the NPC is spawned. Note that npc.getEntity() will be null until this method is
   // called.


### PR DESCRIPTION
The armorstand was not removed when an NPC was despawned, but only when it was destroyed, which caused the Hologram armorstand to be duplicated multiple times

https://user-images.githubusercontent.com/61113150/219803597-8bae4e8b-e586-4268-8720-11effd29df0f.mp4

